### PR TITLE
Add 'actions: read' permissions to security hardening workflow

### DIFF
--- a/.github/workflows/reusable-security-hardening.yml
+++ b/.github/workflows/reusable-security-hardening.yml
@@ -287,6 +287,7 @@ jobs:
     uses: huntridge-labs/hardening-workflows/.github/workflows/linting.yml@2.5.1
     permissions:
       contents: read
+      actions: read
       pull-requests: write
       checks: write
 


### PR DESCRIPTION
Enhance the security hardening workflow by adding 'actions: read' permissions to ensure proper access control.